### PR TITLE
minor change that represents next week more accurately

### DIFF
--- a/src/CalendarStore.php
+++ b/src/CalendarStore.php
@@ -55,7 +55,7 @@ class CalendarStore
             return "In {$carbon->diffInDays()} days";
         }
 
-        if ($carbon->diffInDays() <= 14) {
+        if ($carbon->diffInDays() <= 14 && $carbon->isNextWeek()) {
             return "Next week";
         }
 


### PR DESCRIPTION
Hey there,

I've added a small check for the representable date of next week to more accurate show when an event is _actually_ next week.

**The Scenario**
Consider the following scenario
Event is on 2022-07-29 (a friday in week c)
Weeks run from 

- 2022-07-11 to 2022-07-17 (week a)
- 2022-07-18 to 2022-07-24 (week b)
- 2022-07-25 to 2022-07-31 (week c)

**The issue**

If you were to check the tile on 2022-07-15 (friday on week a) the event would be within 14 days of happening and "Next week would show. However next week is actually week b, which is not the week the the event takes place, thus potentially causing confusion.

**The fix**

Add an extra check to see if the event _actually_ is happening next week, by using the `->isNextWeek()` Carbon comparison method. The default carbon week start day is Monday, this can be changed on application level is this needs changing for a user's needs. I don't think we need to add support for that within the package itself.

**Extra context**
If the event IS happening within 14 days but NOT next week, it will display the full date until it does happen next week. So in our case
The date shows: until 2022-07-17
Next week shows: until 2022-07-22
In x days shows until: 2022-07-27
tomorrow shows: 2022-07-28
today shows: 2022-07-29

Cheers,
Roël

