### PR TITLE
Round diff in days

### DIFF
--- a/src/CalendarStore.php
+++ b/src/CalendarStore.php
@@ -52,7 +52,8 @@ class CalendarStore
         }
 
         if ($carbon->diffInDays(now(), true) < 8) {
-            return "In {$carbon->diffInDays(now(), true)} days";
+            $days = round($carbon->diffInDays(now(), true))
+            return "In {$days} days";
         }
 
         if ($carbon->isNextWeek()) {


### PR DESCRIPTION
`diffInDays` returns a float value, which will contain a lot of decimals. Displaying all those decimals is pretty wack, so I've added a round here to fix that.